### PR TITLE
fix linux alsa card detection in jacksettings

### DIFF
--- a/src/jacksettings.py
+++ b/src/jacksettings.py
@@ -710,7 +710,7 @@ class JackSettingsW(QDialog):
                     if stream_type != '*':
                         stream = value
 
-            if stream_type == stream:
+            if (stream_type == stream) and (name != 'Loopback'):
                 alsaDeviceList.append( "hw:%s,%s [%s]" % (card, device, name) )
 
         return alsaDeviceList


### PR DESCRIPTION
Wrong card/device detection under linux. I've rewrite JackSettingsW.getAlsaDeviceList to get more reliable information and split capture/playback device detection.