### PR TITLE
make it work with KDE 5 (plasma)

### DIFF
--- a/src/systray.py
+++ b/src/systray.py
@@ -47,6 +47,9 @@ try:
             from gi.repository import Gtk, AppIndicator3 as AppIndicator
 
         TrayEngine = "AppIndicator"
+    
+    elif os.getenv("KDE_SESSION_VERSION") >= 5:
+        TrayEngine = "Qt"
 
     elif (os.getenv("KDE_FULL_SESSION") or os.getenv("DESKTOP_SESSION") == "kde-plasma") and not os.path.exists("/etc/debian_version"):
         from PyKDE4.kdeui import KAction, KIcon, KMenu, KStatusNotifierItem


### PR DESCRIPTION
KDE TrayEngine does not show a tray icon in my ArchLinux box. Qt TrayEngine does. Checking for the KDE_SESSION_VERSION is what allows me to know that I am under KDE Plasma 5.