### PR TITLE
Add RPM based distro support to claudia_launcher

### DIFF
--- a/src/claudia_launcher.py
+++ b/src/claudia_launcher.py
@@ -693,6 +693,11 @@ class ClaudiaLauncher(QWidget, ui_claudia_launcher.Ui_ClaudiaLauncherW):
                     if installed == "install":
                         pkglist.append(package.strip())
 
+            elif os.path.exists("/bin/rpm"):
+                pkg_out = getoutput("env LANG=C /bin/rpm -qa --qf \"%{NAME}\n\" 2>/dev/null").split("\n")
+                for package in pkg_out:
+                    pkglist.append(package)
+
             if not "bristol" in pkglist:
                 self.tabWidget.setTabEnabled(iTabBristol, False)
 


### PR DESCRIPTION
Provides the ability to use the built in application database on RPM based distributions like OpenSUSE and Fedora.

Has been tested on OpenSUSE Leap 42.1 and OpenSUSE Tumbleweed
