### PR TITLE
avoid exit from systray prematurely

### DIFF
--- a/src/cadence.py
+++ b/src/cadence.py
@@ -2325,6 +2325,7 @@ if __name__ == '__main__':
     if "--minimized" in app.arguments():
         gui.hide()
         gui.systray.setActionText("show", gui.tr("Restore"))
+        app.setQuitOnLastWindowClosed(False)
     else:
         gui.show()
 


### PR DESCRIPTION
When starting minimized and e.g. Configure Jack and the Close, cadence will exit the systray. This pull request fixes this behaviour, i.e. cadence will exit only with Quit menu entry. (I guess the intended behaviour).