### PR TITLE
Makefile: honor PREFIX environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Created by falkTX
 #
 
-PREFIX  = /usr/local
+PREFIX  ?= /usr/local
 DESTDIR =
 
 LINK   = ln -s


### PR DESCRIPTION
Many packages have makefiles, honoring PREFIX from environment. Unfortunally, it doesn't work in same way, as DESTDIR (don't know, how to achieve that), but still much easier, that sed'ing.