### PR TITLE
Modulable pulseaudio

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,8 +23,8 @@ The required build dependencies are: <i>(devel packages of these)</i>
  - PyQt5 (Py3 version)
 
 On Debian and Ubuntu, use these commands to install all build dependencies: <br/>
-`$ sudo apt-get install libjack-jackd2-dev libqt4-dev qt4-dev-tools` <br/>
-`$ sudo apt-get install python-qt5-dev python3-pyqt5 pyqt5-dev-tools python3-pyqt5.qtsvg`
+`$ sudo apt-get install libjack-jackd2-dev qtbase5-dev, qtbase5-dev-tools` <br/>
+`$ sudo apt-get install python3-pyqt5 python3-pyqt5.qtsvg pyqt5-dev-tools`
 
 To run all the apps/tools, you'll additionally need:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,12 +19,12 @@ Packagers can make use of the 'PREFIX' and 'DESTDIR' variable during install, li
 The required build dependencies are: <i>(devel packages of these)</i>
 
  - JACK
- - Qt4
- - PyQt4 (Py3 version)
+ - Qt5
+ - PyQt5 (Py3 version)
 
 On Debian and Ubuntu, use these commands to install all build dependencies: <br/>
-`$ sudo apt-get install libjack-dev libqt4-dev qt4-dev-tools` <br/>
-`$ sudo apt-get install python-qt4-dev python3-pyqt4 pyqt4-dev-tools`
+`$ sudo apt-get install libjack-jackd2-dev libqt4-dev qt4-dev-tools` <br/>
+`$ sudo apt-get install python-qt5-dev python3-pyqt5 pyqt5-dev-tools python3-pyqt5.qtsvg`
 
 To run all the apps/tools, you'll additionally need:
 

--- a/c++/Makefile.mk
+++ b/c++/Makefile.mk
@@ -7,9 +7,6 @@
 AR  ?= ar
 CC  ?= gcc
 CXX ?= g++
-MOC ?= $(shell pkg-config --variable=moc_location QtCore)
-RCC ?= $(shell pkg-config --variable=rcc_location QtCore)
-UIC ?= $(shell pkg-config --variable=uic_location QtCore)
 STRIP ?= strip
 WINDRES ?= windres
 

--- a/c++/Makefile.mk
+++ b/c++/Makefile.mk
@@ -24,7 +24,7 @@ BASE_FLAGS  = -O0 -g -Wall -Wextra
 BASE_FLAGS += -DDEBUG
 STRIP       = true # FIXME
 else
-BASE_FLAGS  = -O3 -ffast-math -mtune=generic -Wall -Wextra
+BASE_FLAGS  = -O3 -ffast-math -Wall -Wextra
 BASE_FLAGS += -DNDEBUG
 endif
 

--- a/c++/Makefile.mk
+++ b/c++/Makefile.mk
@@ -24,7 +24,7 @@ BASE_FLAGS  = -O0 -g -Wall -Wextra
 BASE_FLAGS += -DDEBUG
 STRIP       = true # FIXME
 else
-BASE_FLAGS  = -O3 -ffast-math -mtune=generic -msse -mfpmath=sse -Wall -Wextra
+BASE_FLAGS  = -O3 -ffast-math -mtune=generic -Wall -Wextra
 BASE_FLAGS += -DNDEBUG
 endif
 

--- a/c++/Makefile.mk
+++ b/c++/Makefile.mk
@@ -7,6 +7,9 @@
 AR  ?= ar
 CC  ?= gcc
 CXX ?= g++
+MOC ?= $(shell pkg-config --variable=moc_location QtCore)
+RCC ?= $(shell pkg-config --variable=rcc_location QtCore)
+UIC ?= $(shell pkg-config --variable=uic_location QtCore)
 STRIP ?= strip
 WINDRES ?= windres
 
@@ -22,7 +25,6 @@ DEBUG ?= false
 ifeq ($(DEBUG),true)
 BASE_FLAGS  = -O0 -g -Wall -Wextra
 BASE_FLAGS += -DDEBUG
-STRIP       = true # FIXME
 else
 BASE_FLAGS  = -O3 -ffast-math -Wall -Wextra
 BASE_FLAGS += -DNDEBUG
@@ -36,6 +38,10 @@ LINK_FLAGS      = $(LDFLAGS)
 
 ifneq ($(DEBUG),true)
 BUILD_CXX_FLAGS += -DQT_NO_DEBUG -DQT_NO_DEBUG_STREAM -DQT_NO_DEBUG_OUTPUT
+endif
+
+ifneq ($(SKIP_STRIPPING),true)
+LINK_FLAGS += -Wl,--strip-all
 endif
 
 # --------------------------------------------------------------

--- a/c++/jackmeter/Makefile
+++ b/c++/jackmeter/Makefile
@@ -31,10 +31,10 @@ OBJS = \
 all: cadence-jackmeter
 
 cadence-jackmeter: $(FILES) $(OBJS)
-	$(CXX) $(OBJS) $(LINK_FLAGS) -ldl -o $@ && $(STRIP) $@
+	$(CXX) $(OBJS) $(LINK_FLAGS) -ldl -o $@
 
 cadence-jackmeter.exe: $(FILES) $(OBJS) icon.o
-	$(CXX) $(OBJS) icon.o $(LINK_FLAGS) -limm32 -lole32 -luuid -lwinspool -lws2_32 -mwindows -o $@ && $(STRIP) $@
+	$(CXX) $(OBJS) icon.o $(LINK_FLAGS) -limm32 -lole32 -luuid -lwinspool -lws2_32 -mwindows -o $@
 
 # --------------------------------------------------------------
 

--- a/c++/xycontroller/Makefile
+++ b/c++/xycontroller/Makefile
@@ -35,10 +35,10 @@ OBJS  = xycontroller.o \
 all: cadence-xycontroller
 
 cadence-xycontroller: $(FILES) $(OBJS)
-	$(CXX) $(OBJS) $(LINK_FLAGS) -ldl -o $@ && $(STRIP) $@
+	$(CXX) $(OBJS) $(LINK_FLAGS) -ldl -o $@
 
 cadence-xycontroller.exe: $(FILES) $(OBJS) icon.o
-	$(CXX) $(OBJS) icon.o $(LINK_FLAGS) -limm32 -lole32 -luuid -lwinspool -lws2_32 -mwindows -o $@ && $(STRIP) $@
+	$(CXX) $(OBJS) icon.o $(LINK_FLAGS) -limm32 -lole32 -luuid -lwinspool -lws2_32 -mwindows -o $@
 
 # --------------------------------------------------------------
 

--- a/data/cadence-pulse2jack
+++ b/data/cadence-pulse2jack
@@ -43,38 +43,66 @@ else
 fi
 
 # ----------------------------------------------
+wanted_capture_ports=0   # -1 means default
+wanted_playback_ports=0  # -1 means default
 
-PLAY_ONLY="no"
+arg_is_for=""
 
-case $1 in
-    -h|--h|--help)
-echo "usage: $0 [command]
+for arg in "$@";do
+    case "$arg" in
+        -h|--h|--help)
+    echo "usage: $0 [command]
+    
+    -p           Playback only with default number of channels
+    -p <NUMBER>  Number of playback channels
+    -c           Capture only with default number of channels
+    -c <NUMBER>  Number of capture channels
 
-  -p, --play    Playback mode only
+    -h, --help   Show this help menu
+        --dummy  Don't do anything, just create the needed files
 
-  -h, --help    Show this help menu
-      --dummy   Don't do anything, just create the needed files
+    NOTE:
+    When runned with no arguments, $(basename "$0") will
+    activate PulseAudio with both playback and record modes with default number of channels.
+    "
+    exit
+        ;;
+        --dummy)
+    exit
+        ;;
+        -c|--capture)
+            arg_is_for="capture"
+            wanted_capture_ports=-1 # -1 means default, if no (correct) argument is given.
+        ;;
+        -p|--play|--playback)
+            arg_is_for="playback"
+            wanted_playback_ports=-1
+        ;;
+        * )
+            case "$arg_is_for" in
+                "capture")
+                    [ "$arg" -ge 0 ] 2>/dev/null && wanted_capture_ports="$arg"
+                ;;
+                "playback")
+                    [ "$arg" -ge 0 ] 2>/dev/null && wanted_playback_ports="$arg"
+                ;;
+            esac
+        ;;
+    esac
+done
 
-NOTE:
- When runned with no arguments, pulse2jack will
- activate PulseAudio with both playback and record modes.
-"
-exit
-    ;;
 
-    --dummy)
-exit
-    ;;
+if [ $wanted_capture_ports == 0 ] && [ $wanted_playback_ports == 0 ];then
+    #no sense to want to start/bridge pulseaudio without ports, set as default
+    capture_ports=-1  # -1 means default
+    playback_ports=-1 # -1 means default
+fi
 
-    -p|--p|--play)
-PLAY_ONLY="yes"
-FILE=$INSTALL_PREFIX/share/cadence/pulse2jack/play.pa
-    ;;
+str_capture="channels=$wanted_capture_ports"   #used for pulseaudio commands
+str_playback="channels=$wanted_playback_ports" ##
 
-    *)
-FILE=$INSTALL_PREFIX/share/cadence/pulse2jack/play+rec.pa
-    ;;
-esac
+[ $wanted_capture_ports  == -1 ] && str_capture=""  # -1 means default, no command channels=n
+[ $wanted_playback_ports == -1 ] && str_playback="" ##
 
 # ----------------------------------------------
 
@@ -88,40 +116,166 @@ IsPulseAudioRunning()
     fi
 }
 
-if (IsPulseAudioRunning); then
+StartBridged()
 {
-    if (`jack_lsp | grep "PulseAudio JACK Sink:" > /dev/null`); then
-    {
-        echo "PulseAudio is already running and bridged to JACK"
-    }
-    else
-    {
-        echo "PulseAudio is already running, bridge it..."
-
-        if [ "$PLAY_ONLY" == "yes" ]; then
-        {
-            pactl load-module module-jack-sink > /dev/null
-            pacmd set-default-source jack_in > /dev/null
-        }
-        else
-        {
-            pactl load-module module-jack-sink > /dev/null
-            pactl load-module module-jack-source > /dev/null
-            pacmd set-default-sink jack_out > /dev/null
-            pacmd set-default-source jack_in > /dev/null
-        }
-        fi
-
-        echo "Done"
-    }
-    fi
-}
-else
-{
-    if (`pulseaudio --daemonize --high-priority --realtime --exit-idle-time=-1 --file=$FILE -n`); then
+    #write pulseaudio config file in a tmp file
+    pa_file=$(mktemp --suffix .pa)
+    echo .fail > $pa_file
+    
+    ### Automatically restore the volume of streams and devices
+    echo load-module module-device-restore  >> $pa_file
+    echo load-module module-stream-restore  >> $pa_file
+    echo load-module module-card-restore    >> $pa_file
+    
+    ### Load Jack modules
+    [ $wanted_capture_ports  != 0 ] && echo load-module module-jack-source $str_capture  >> $pa_file
+    [ $wanted_playback_ports != 0 ] && echo load-module module-jack-sink   $str_playback >> $pa_file
+    
+    ### Load unix protocol
+    echo load-module module-native-protocol-unix >> $pa_file
+    
+    ### Automatically restore the default sink/source when changed by the user
+    ### during runtime
+    ### NOTE: This should be loaded as early as possible so that subsequent modules
+    ### that look up the default sink/source get the right value
+    echo load-module module-default-device-restore >> $pa_file
+    
+    ### Automatically move streams to the default sink if the sink they are
+    ### connected to dies, similar for sources
+    echo load-module module-rescue-streams >> $pa_file
+    
+    ### Make sure we always have a sink around, even if it is a null sink.
+    echo load-module module-always-sink >> $pa_file
+    
+    ### Make Jack default
+    [ $wanted_capture_ports  != 0 ] && echo set-default-source jack_in >> $pa_file
+    [ $wanted_playback_ports != 0 ] && echo set-default-sink jack_out  >> $pa_file
+    
+    if (`pulseaudio --daemonize --high-priority --realtime --exit-idle-time=-1 --file=$pa_file -n`); then
         echo "Initiated PulseAudio successfully!"
     else
         echo "Failed to initialize PulseAudio!"
     fi
+}
+
+killReStart()
+{
+    pulseaudio -k && StartBridged
+    exit
+}
+
+JackNotRunning()
+{ 
+    echo "JACK seems not running, start JACK before bridge PulseAudio"
+    exit 1
+}
+
+if (IsPulseAudioRunning); then
+{   
+    #count all Jack Audio Physical ports
+    all_jack_lsp=$(jack_lsp -p -t) || JackNotRunning
+    output_physical_lines=$(echo "$all_jack_lsp"|grep -n "output,physical,"|cut -d':' -f1)
+    input_physical_lines=$( echo "$all_jack_lsp"|grep -n "input,physical," |cut -d':' -f1)
+    audio_lines=$(echo "$all_jack_lsp" |grep -n " audio"|cut -d':' -f1)
+    
+    capture_physical_ports=0
+    playback_physical_ports=0
+    
+    for out_phy_line in $output_physical_lines;do
+        if echo "$audio_lines"|grep -q $(($out_phy_line + 1));then
+            ((capture_physical_ports++))
+        fi
+    done
+    
+    for in_phy_line in $input_physical_lines;do
+        if echo "$audio_lines"|grep -q $(($in_phy_line + 1));then
+            ((playback_physical_ports++))
+        fi
+    done
+    
+    #count PulseAudio jack ports
+    current_playback_ports=$(echo "$all_jack_lsp"|grep ^"PulseAudio JACK Sink:"  |wc -l)
+    current_capture_ports=$( echo "$all_jack_lsp"|grep ^"PulseAudio JACK Source:"|wc -l)
+    
+    #if number of pulseaudio ports equal to physical ports, consider pulseaudio module is running the default mode (no channels=n)
+    [ $current_capture_ports  == $capture_physical_ports  ] && current_capture_ports=-1
+    [ $current_playback_ports == $playback_physical_ports ] && current_playback_ports=-1
+    [ $wanted_capture_ports   == $capture_physical_ports  ] && wanted_capture_ports=-1
+    [ $wanted_playback_ports  == $playback_physical_ports ] && wanted_playback_ports=-1
+    
+    if [ $wanted_capture_ports == $current_capture_ports ] && [ $wanted_playback_ports == $current_playback_ports ];then
+        echo "PulseAudio is already started and bridged to Jack with $current_capture_ports inputs and $current_playback_ports outputs, nothing to do !"
+        exit
+    fi
+    
+    if [ $current_capture_ports != $wanted_capture_ports ];then
+        if [ $current_capture_ports != 0 ];then
+            echo "unload PulseAudio JACK Source"
+            pactl unload-module module-jack-source > /dev/null || killReStart
+        fi
+        
+        if [ $wanted_capture_ports != 0 ];then
+            echo "load PulseAudio JACK Source $str_capture"
+            
+            pactl load-module module-jack-source $str_capture > /dev/null
+            pacmd set-default-source jack_in > /dev/null
+        fi
+    fi
+    
+    if [ $current_playback_ports != $wanted_playback_ports ];then
+        if [ $current_playback_ports != 0 ];then
+            echo "unload PulseAudio JACK Sink"
+            pactl unload-module module-jack-sink > /dev/null || killReStart
+        fi
+        
+        if [ $wanted_playback_ports != 0 ];then
+            echo "load PulseAudio JACK Sink $str_playback"
+            
+            pactl load-module module-jack-sink $str_playback > /dev/null
+            pactl set-default-sink jack_out > /dev/null
+        fi
+    fi
+}
+else
+{     
+    StartBridged
+#     #write pulseaudio config file in a tmp file
+#     pa_file=$(mktemp --suffix .pa)
+#     echo .fail > $pa_file
+#     
+#     ### Automatically restore the volume of streams and devices
+#     echo load-module module-device-restore  >> $pa_file
+#     echo load-module module-stream-restore  >> $pa_file
+#     echo load-module module-card-restore    >> $pa_file
+#     
+#     ### Load Jack modules
+#     [ $wanted_capture_ports  != 0 ] && echo load-module module-jack-source $str_capture  >> $pa_file
+#     [ $wanted_playback_ports != 0 ] && echo load-module module-jack-sink   $str_playback >> $pa_file
+#     
+#     ### Load unix protocol
+#     echo load-module module-native-protocol-unix >> $pa_file
+#     
+#     ### Automatically restore the default sink/source when changed by the user
+#     ### during runtime
+#     ### NOTE: This should be loaded as early as possible so that subsequent modules
+#     ### that look up the default sink/source get the right value
+#     echo load-module module-default-device-restore >> $pa_file
+#     
+#     ### Automatically move streams to the default sink if the sink they are
+#     ### connected to dies, similar for sources
+#     echo load-module module-rescue-streams >> $pa_file
+#     
+#     ### Make sure we always have a sink around, even if it is a null sink.
+#     echo load-module module-always-sink >> $pa_file
+#     
+#     ### Make Jack default
+#     [ $wanted_capture_ports  != 0 ] && echo set-default-source jack_in >> $pa_file
+#     [ $wanted_playback_ports != 0 ] && echo set-default-sink jack_out  >> $pa_file
+#     
+#     if (`pulseaudio --daemonize --high-priority --realtime --exit-idle-time=-1 --file=$pa_file -n`); then
+#         echo "Initiated PulseAudio successfully!"
+#     else
+#         echo "Failed to initialize PulseAudio!"
+#     fi
 }
 fi

--- a/resources/ui/cadence.ui
+++ b/resources/ui/cadence.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>740</width>
-    <height>564</height>
+    <height>680</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -544,7 +544,16 @@
              <string>JACK Bridges</string>
             </property>
             <layout class="QGridLayout" name="gridLayout_5">
-             <property name="margin">
+             <property name="leftMargin">
+              <number>2</number>
+             </property>
+             <property name="topMargin">
+              <number>2</number>
+             </property>
+             <property name="rightMargin">
+              <number>2</number>
+             </property>
+             <property name="bottomMargin">
               <number>2</number>
              </property>
              <item row="0" column="0">
@@ -572,8 +581,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>360</width>
-                  <height>100</height>
+                  <width>435</width>
+                  <height>130</height>
                  </rect>
                 </property>
                 <attribute name="label">
@@ -720,8 +729,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>360</width>
-                  <height>97</height>
+                  <width>435</width>
+                  <height>130</height>
                  </rect>
                 </property>
                 <attribute name="label">
@@ -854,8 +863,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>360</width>
-                  <height>97</height>
+                  <width>435</width>
+                  <height>130</height>
                  </rect>
                 </property>
                 <attribute name="label">
@@ -917,6 +926,13 @@
                     </widget>
                    </item>
                    <item>
+                    <widget class="QPushButton" name="b_pulse_channels">
+                     <property name="text">
+                      <string>Channels</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
                     <spacer name="horizontalSpacer_13">
                      <property name="orientation">
                       <enum>Qt::Horizontal</enum>
@@ -953,13 +969,6 @@
                     <widget class="QCheckBox" name="cb_pulse_autostart">
                      <property name="text">
                       <string>Auto-start at login</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QToolButton" name="tb_pulse_options">
-                     <property name="text">
-                      <string>...</string>
                      </property>
                     </widget>
                    </item>
@@ -1572,7 +1581,7 @@
              <string>Audio Plugins PATH</string>
             </property>
             <property name="textAlignment">
-             <set>AlignHCenter|AlignVCenter|AlignCenter</set>
+             <set>AlignCenter</set>
             </property>
             <property name="flags">
              <set>ItemIsSelectable|ItemIsEnabled</set>
@@ -1583,7 +1592,7 @@
              <string>Default Applications</string>
             </property>
             <property name="textAlignment">
-             <set>AlignHCenter|AlignVCenter|AlignCenter</set>
+             <set>AlignCenter</set>
             </property>
             <property name="flags">
              <set>ItemIsSelectable|ItemIsEnabled</set>
@@ -1594,7 +1603,7 @@
              <string>WineASIO</string>
             </property>
             <property name="textAlignment">
-             <set>AlignHCenter|AlignVCenter|AlignCenter</set>
+             <set>AlignCenter</set>
             </property>
             <property name="flags">
              <set>ItemIsSelectable|ItemIsEnabled</set>
@@ -1613,7 +1622,16 @@
            </property>
            <widget class="QWidget" name="page_plugins">
             <layout class="QGridLayout" name="gridLayout_6">
-             <property name="margin">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
               <number>0</number>
              </property>
              <item row="3" column="1">
@@ -1681,8 +1699,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>416</width>
-                  <height>334</height>
+                  <width>413</width>
+                  <height>401</height>
                  </rect>
                 </property>
                 <attribute name="label">
@@ -1711,8 +1729,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>94</width>
-                  <height>66</height>
+                  <width>96</width>
+                  <height>86</height>
                  </rect>
                 </property>
                 <attribute name="label">
@@ -1741,8 +1759,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>94</width>
-                  <height>66</height>
+                  <width>96</width>
+                  <height>86</height>
                  </rect>
                 </property>
                 <attribute name="label">
@@ -1771,8 +1789,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>94</width>
-                  <height>66</height>
+                  <width>96</width>
+                  <height>86</height>
                  </rect>
                 </property>
                 <attribute name="label">
@@ -1832,11 +1850,20 @@
            </widget>
            <widget class="QWidget" name="page_apps">
             <layout class="QGridLayout" name="gridLayout_7">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
              <property name="verticalSpacing">
               <number>20</number>
-             </property>
-             <property name="margin">
-              <number>0</number>
              </property>
              <item row="1" column="0">
               <widget class="QCheckBox" name="ch_app_image">
@@ -2063,7 +2090,16 @@
            </widget>
            <widget class="QWidget" name="page_wineasio">
             <layout class="QVBoxLayout" name="verticalLayout_17">
-             <property name="margin">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
               <number>0</number>
              </property>
              <item>

--- a/resources/ui/cadence.ui
+++ b/resources/ui/cadence.ui
@@ -785,7 +785,7 @@
                    <item>
                     <widget class="QPushButton" name="b_a2j_export_hw">
                      <property name="text">
-                      <string>Export HW...</string>
+                      <string>Export HW ports and (re)start</string>
                      </property>
                     </widget>
                    </item>
@@ -823,16 +823,16 @@
                     </spacer>
                    </item>
                    <item>
-                    <widget class="QCheckBox" name="cb_a2j_autostart">
+                    <widget class="QCheckBox" name="cb_a2j_autoexport">
                      <property name="text">
-                      <string>Auto-start at login</string>
+                      <string>Export ports on startup</string>
                      </property>
                     </widget>
                    </item>
                    <item>
-                    <widget class="QToolButton" name="tb_a2j_options">
+                    <widget class="QCheckBox" name="cb_a2j_autostart">
                      <property name="text">
-                      <string>...</string>
+                      <string>Start with Jack</string>
                      </property>
                     </widget>
                    </item>

--- a/resources/ui/cadence.ui
+++ b/resources/ui/cadence.ui
@@ -785,7 +785,7 @@
                    <item>
                     <widget class="QPushButton" name="b_a2j_export_hw">
                      <property name="text">
-                      <string>Export HW ports and (re)start</string>
+                      <string>Export HW ports</string>
                      </property>
                     </widget>
                    </item>

--- a/resources/ui/cadence.ui
+++ b/resources/ui/cadence.ui
@@ -783,13 +783,6 @@
                     </widget>
                    </item>
                    <item>
-                    <widget class="QPushButton" name="b_a2j_export_hw">
-                     <property name="text">
-                      <string>Export HW ports</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
                     <spacer name="horizontalSpacer_8">
                      <property name="orientation">
                       <enum>Qt::Horizontal</enum>
@@ -825,7 +818,7 @@
                    <item>
                     <widget class="QCheckBox" name="cb_a2j_autoexport">
                      <property name="text">
-                      <string>Export ports on startup</string>
+                      <string>Export hardware ports</string>
                      </property>
                     </widget>
                    </item>

--- a/resources/ui/cadence_tb_pa.ui
+++ b/resources/ui/cadence_tb_pa.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>317</width>
-    <height>72</height>
+    <width>218</width>
+    <height>124</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,11 +15,60 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QCheckBox" name="cb_playback_only">
-     <property name="text">
-      <string>Playback Mode only</string>
-     </property>
-    </widget>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelPulseInputs">
+       <property name="text">
+        <string>Input Channels :</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelPulseOutputs">
+       <property name="text">
+        <string>Output Channels :</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QSpinBox" name="spinBoxPulseInputs">
+       <property name="specialValueText">
+        <string>Default</string>
+       </property>
+       <property name="minimum">
+        <number>-1</number>
+       </property>
+       <property name="maximum">
+        <number>10</number>
+       </property>
+       <property name="value">
+        <number>-1</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QSpinBox" name="spinBoxPulseOutputs">
+       <property name="specialValueText">
+        <string>Default</string>
+       </property>
+       <property name="minimum">
+        <number>-1</number>
+       </property>
+       <property name="maximum">
+        <number>10</number>
+       </property>
+       <property name="value">
+        <number>-1</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/src/cadence.py
+++ b/src/cadence.py
@@ -519,13 +519,13 @@ class ForceRestartThread(QThread):
         QThread.__init__(self, parent)
 
         self.m_wasStarted = False
-        self.m_a2jExportHW = False
 
     def wasJackStarted(self):
         return self.m_wasStarted
 
     def startA2J(self):
-        gDBus.a2j.set_hw_export(self.m_a2jExportHW)
+        if not gDBus.a2j.get_hw_export() and GlobalSettings.value("A2J/AutoExport", True, type=bool):
+            gDBus.a2j.set_hw_export(True)
         gDBus.a2j.start()
 
     def run(self):
@@ -574,8 +574,7 @@ class ForceRestartThread(QThread):
         self.progressChanged.emit(94)
 
         # ALSA-MIDI
-        if GlobalSettings.value("A2J/AutoStart", True, type=bool) and gDBus.a2j and not bool(gDBus.a2j.is_started()):
-            self.m_a2jExportHW = GlobalSettings.value("A2J/ExportHW", True, type=bool)
+        if GlobalSettings.value("A2J/AutoStart", True, type=bool) and not bool(gDBus.a2j.is_started()):
             runFunctionInMainThread(self.startA2J)
 
         self.progressChanged.emit(96)
@@ -713,24 +712,6 @@ class ToolBarAlsaAudioDialog(QDialog, ui_cadence_tb_alsa.Ui_Dialog):
         asoundrcFd = open(self.asoundrcFile, "w")
         asoundrcFd.write(asoundrc_aloop.replace("channels 2\n", "channels %i\n" % channels) + "\n")
         asoundrcFd.close()
-
-    def done(self, r):
-        QDialog.done(self, r)
-        self.close()
-
-# Additional ALSA MIDI options
-class ToolBarA2JDialog(QDialog, ui_cadence_tb_a2j.Ui_Dialog):
-    def __init__(self, parent):
-        QDialog.__init__(self, parent)
-        self.setupUi(self)
-
-        self.cb_export_hw.setChecked(GlobalSettings.value("A2J/ExportHW", True, type=bool))
-
-        self.accepted.connect(self.slot_setOptions)
-
-    @pyqtSlot()
-    def slot_setOptions(self):
-        GlobalSettings.setValue("A2J/ExportHW", self.cb_export_hw.isChecked())
 
     def done(self, r):
         QDialog.done(self, r)
@@ -1104,7 +1085,6 @@ class CadenceMainW(QMainWindow, ui_cadence.Ui_CadenceMainW):
             self.systray.connect("alsa_stop", self.slot_AlsaBridgeStop)
             self.systray.connect("a2j_start", self.slot_A2JBridgeStart)
             self.systray.connect("a2j_stop", self.slot_A2JBridgeStop)
-            self.systray.connect("a2j_export_hw", self.slot_A2JBridgeExportHW)
             self.systray.connect("pulse_start", self.slot_PulseAudioBridgeStart)
             self.systray.connect("pulse_stop", self.slot_PulseAudioBridgeStop)
 
@@ -1150,8 +1130,6 @@ class CadenceMainW(QMainWindow, ui_cadence.Ui_CadenceMainW):
         self.b_a2j_start.clicked.connect(self.slot_A2JBridgeStart)
         self.b_a2j_stop.clicked.connect(self.slot_A2JBridgeStop)
         self.b_a2j_export_hw.clicked.connect(self.slot_A2JBridgeExportHW)
-        self.tb_a2j_options.clicked.connect(self.slot_A2JBridgeOptions)
-
         self.b_pulse_start.clicked.connect(self.slot_PulseAudioBridgeStart)
         self.b_pulse_stop.clicked.connect(self.slot_PulseAudioBridgeStop)
         self.tb_pulse_options.clicked.connect(self.slot_PulseAudioBridgeOptions)
@@ -1290,6 +1268,7 @@ class CadenceMainW(QMainWindow, ui_cadence.Ui_CadenceMainW):
         else:
             self.toolBox_alsamidi.setEnabled(False)
             self.cb_a2j_autostart.setChecked(False)
+            self.cb_a2j_autoexport.setChecked(False)
             self.label_bridge_a2j.setText("ALSA MIDI Bridge is not installed")
             self.settings.setValue("A2J/AutoStart", False)
 
@@ -1358,8 +1337,13 @@ class CadenceMainW(QMainWindow, ui_cadence.Ui_CadenceMainW):
         self.m_timer500 = self.startTimer(500)
 
         if gDBus.a2j and not gDBus.a2j.is_started():
-            self.b_a2j_start.setEnabled(True)
-            self.systray.setActionEnabled("a2j_start", True)
+            if GlobalSettings.value("A2J/AutoStart", True, type=bool):
+                if not gDBus.a2j.get_hw_export() and GlobalSettings.value("A2J/AutoExport", True, type=bool):
+                    gDBus.a2j.set_hw_export(True)
+                gDBus.a2j.start()
+            else:
+                self.b_a2j_start.setEnabled(True)
+                self.systray.setActionEnabled("a2j_start", True)
 
         self.checkAlsaAudio()
         self.checkPulseAudio()
@@ -1405,7 +1389,6 @@ class CadenceMainW(QMainWindow, ui_cadence.Ui_CadenceMainW):
     def a2jStarted(self):
         self.b_a2j_start.setEnabled(False)
         self.b_a2j_stop.setEnabled(True)
-        self.b_a2j_export_hw.setEnabled(False)
         self.systray.setActionEnabled("a2j_start", False)
         self.systray.setActionEnabled("a2j_stop", True)
         self.systray.setActionEnabled("a2j_export_hw", False)
@@ -1415,7 +1398,6 @@ class CadenceMainW(QMainWindow, ui_cadence.Ui_CadenceMainW):
         jackRunning = bool(gDBus.jack and gDBus.jack.IsStarted())
         self.b_a2j_start.setEnabled(jackRunning)
         self.b_a2j_stop.setEnabled(False)
-        self.b_a2j_export_hw.setEnabled(True)
         self.systray.setActionEnabled("a2j_start", jackRunning)
         self.systray.setActionEnabled("a2j_stop", False)
         self.systray.setActionEnabled("a2j_export_hw", True)
@@ -1790,16 +1772,10 @@ class CadenceMainW(QMainWindow, ui_cadence.Ui_CadenceMainW):
 
     @pyqtSlot()
     def slot_A2JBridgeExportHW(self):
-        ask = QMessageBox.question(self, self.tr("ALSA MIDI Hardware Export"), self.tr("Enable Hardware Export on the ALSA MIDI Bridge?"), QMessageBox.Yes|QMessageBox.No|QMessageBox.Cancel, QMessageBox.Yes)
-
-        if ask == QMessageBox.Yes:
-            gDBus.a2j.set_hw_export(True)
-        elif ask == QMessageBox.No:
-            gDBus.a2j.set_hw_export(False)
-
-    @pyqtSlot()
-    def slot_A2JBridgeOptions(self):
-        ToolBarA2JDialog(self).exec_()
+        if bool(gDBus.a2j.is_started()):
+            gDBus.a2j.stop()
+        gDBus.a2j.set_hw_export(True)
+        gDBus.a2j.start()
 
     @pyqtSlot()
     def slot_PulseAudioBridgeStart(self):
@@ -2304,6 +2280,7 @@ class CadenceMainW(QMainWindow, ui_cadence.Ui_CadenceMainW):
         GlobalSettings.setValue("JACK/AutoStart", self.cb_jack_autostart.isChecked())
         GlobalSettings.setValue("ALSA-Audio/BridgeIndexType", self.cb_alsa_type.currentIndex())
         GlobalSettings.setValue("A2J/AutoStart", self.cb_a2j_autostart.isChecked())
+        GlobalSettings.setValue("A2J/AutoExport", self.cb_a2j_autoexport.isChecked())
         GlobalSettings.setValue("Pulse2JACK/AutoStart", (havePulseAudio and self.cb_pulse_autostart.isChecked()))
 
     def loadSettings(self, geometry):
@@ -2314,6 +2291,7 @@ class CadenceMainW(QMainWindow, ui_cadence.Ui_CadenceMainW):
 
         self.cb_jack_autostart.setChecked(GlobalSettings.value("JACK/AutoStart", wantJackStart, type=bool))
         self.cb_a2j_autostart.setChecked(GlobalSettings.value("A2J/AutoStart", True, type=bool))
+        self.cb_a2j_autoexport.setChecked(GlobalSettings.value("A2J/AutoExport", True, type=bool))
         self.cb_pulse_autostart.setChecked(GlobalSettings.value("Pulse2JACK/AutoStart", havePulseAudio and not usingAlsaLoop, type=bool))
 
     def timerEvent(self, event):

--- a/src/cadence.py
+++ b/src/cadence.py
@@ -55,16 +55,7 @@ try:
     from dbus.mainloop.pyqt5 import DBusQtMainLoop
     haveDBus = True
 except:
-    kxstudioWorkaround = "/opt/kxstudio/python3/dist-packages/dbus/mainloop"
-    if os.path.exists(kxstudioWorkaround):
-        try:
-            sys.path.insert(1, kxstudioWorkaround)
-            from pyqt5 import DBusQtMainLoop
-            haveDBus = True
-        except:
-            haveDBus = False
-    else:
-        haveDBus = False
+    haveDBus = False
 
 # ------------------------------------------------------------------------------------------------------------
 # Check for PulseAudio and Wine

--- a/src/cadence.py
+++ b/src/cadence.py
@@ -1310,7 +1310,7 @@ class CadenceMainW(QMainWindow, ui_cadence.Ui_CadenceMainW):
 
     def jackStarted(self):
         self.m_last_dsp_load = gDBus.jack.GetLoad()
-        self.m_last_xruns    = gDBus.jack.GetXruns()
+        self.m_last_xruns    = int(gDBus.jack.GetXruns())
         self.m_last_buffer_size = gDBus.jack.GetBufferSize()
 
         self.b_jack_start.setEnabled(False)
@@ -2324,7 +2324,7 @@ class CadenceMainW(QMainWindow, ui_cadence.Ui_CadenceMainW):
         if event.timerId() == self.m_timer500:
             if gDBus.jack and self.m_last_dsp_load != None:
                 next_dsp_load = gDBus.jack.GetLoad()
-                next_xruns    = gDBus.jack.GetXruns()
+                next_xruns    = int(gDBus.jack.GetXruns())
                 needUpdateTip = False
 
                 if self.m_last_dsp_load != next_dsp_load:

--- a/src/cadence.py
+++ b/src/cadence.py
@@ -1667,7 +1667,7 @@ class CadenceMainW(QMainWindow, ui_cadence.Ui_CadenceMainW):
 
     @pyqtSlot()
     def slot_JackServerStop(self):
-        if gDBus.a2j:
+        if gDBus.a2j and bool(gDBus.a2j.is_started()):
             gDBus.a2j.stop()
         try:
             gDBus.jack.StopServer()

--- a/src/catia.py
+++ b/src/catia.py
@@ -31,16 +31,7 @@ try:
     from dbus.mainloop.pyqt5 import DBusQtMainLoop
     haveDBus = True
 except:
-    kxstudioWorkaround = "/opt/kxstudio/python3/dist-packages/dbus/mainloop"
-    if os.path.exists(kxstudioWorkaround):
-        try:
-            sys.path.insert(1, kxstudioWorkaround)
-            from pyqt5 import DBusQtMainLoop
-            haveDBus = True
-        except:
-            haveDBus = False
-    else:
-        haveDBus = False
+    haveDBus = False
 
 # ------------------------------------------------------------------------------------------------------------
 # Try Import OpenGL

--- a/src/claudia.py
+++ b/src/claudia.py
@@ -1732,7 +1732,7 @@ class ClaudiaMainW(AbstractCanvasJackClass):
 
     @pyqtSlot()
     def slot_room_delete_m(self):
-        room_name = self.sender().proeprty("data")
+        room_name = self.sender().property("data")
         if room_name:
             gDBus.ladish_studio.DeleteRoom(room_name)
 
@@ -1966,7 +1966,7 @@ class ClaudiaMainW(AbstractCanvasJackClass):
                     ladish_room = gDBus.bus.get_object("org.ladish", room_path)
                     room_name = ladish_room.GetName()
                     act_x_room = QAction(room_name, self.ui.menu_room_delete)
-                    act_x_room.setProperty("data", studio_name);
+                    act_x_room.setProperty("data", room_name);
                     self.ui.menu_room_delete.addAction(act_x_room)
                     act_x_room.triggered.connect(self.slot_room_delete_m)
         else:

--- a/src/claudia.py
+++ b/src/claudia.py
@@ -51,16 +51,7 @@ try:
     from dbus.mainloop.pyqt5 import DBusQtMainLoop
     haveDBus = True
 except:
-    kxstudioWorkaround = "/opt/kxstudio/python3/dist-packages/dbus/mainloop"
-    if os.path.exists(kxstudioWorkaround):
-        try:
-            sys.path.insert(1, kxstudioWorkaround)
-            from pyqt5 import DBusQtMainLoop
-            haveDBus = True
-        except:
-            haveDBus = False
-    else:
-        haveDBus = False
+    haveDBus = False
 
 # ------------------------------------------------------------------------------------------------------------
 # Try Import OpenGL

--- a/src/claudia.py
+++ b/src/claudia.py
@@ -1686,7 +1686,7 @@ class ClaudiaMainW(AbstractCanvasJackClass):
 
     @pyqtSlot()
     def slot_studio_load_m(self):
-        studio_name = self.sender().text()
+        studio_name = self.sender().property("data")
         if studio_name:
             gDBus.ladish_control.LoadStudio(studio_name)
 
@@ -1720,7 +1720,7 @@ class ClaudiaMainW(AbstractCanvasJackClass):
 
     @pyqtSlot()
     def slot_studio_delete_m(self):
-        studio_name = self.sender().text()
+        studio_name = self.sender().property("data")
         if studio_name:
             gDBus.ladish_control.DeleteStudio(studio_name)
 
@@ -1732,7 +1732,7 @@ class ClaudiaMainW(AbstractCanvasJackClass):
 
     @pyqtSlot()
     def slot_room_delete_m(self):
-        room_name = self.sender().text()
+        room_name = self.sender().proeprty("data")
         if room_name:
             gDBus.ladish_studio.DeleteRoom(room_name)
 
@@ -1757,7 +1757,7 @@ class ClaudiaMainW(AbstractCanvasJackClass):
 
     @pyqtSlot()
     def slot_project_load_m(self):
-        act_x_text = self.sender().text()
+        act_x_text = self.sender().property("data")
         if act_x_text:
             proj_path = "/" + act_x_text.rsplit("[/", 1)[-1].rsplit("]", 1)[0]
             gDBus.ladish_room.LoadProject(proj_path)
@@ -1933,6 +1933,7 @@ class ClaudiaMainW(AbstractCanvasJackClass):
             for studio in studio_list:
                 studio_name  = str(studio[iStudioListName])
                 act_x_studio = QAction(studio_name, self.ui.menu_studio_load)
+                act_x_studio.setProperty("data", studio_name);
                 self.ui.menu_studio_load.addAction(act_x_studio)
                 act_x_studio.triggered.connect(self.slot_studio_load_m)
 
@@ -1949,6 +1950,7 @@ class ClaudiaMainW(AbstractCanvasJackClass):
             for studio in studio_list:
                 studio_name = str(studio[iStudioListName])
                 act_x_studio = QAction(studio_name, self.ui.menu_studio_delete)
+                act_x_studio.setProperty("data", studio_name);
                 self.ui.menu_studio_delete.addAction(act_x_studio)
                 act_x_studio.triggered.connect(self.slot_studio_delete_m)
 
@@ -1964,6 +1966,7 @@ class ClaudiaMainW(AbstractCanvasJackClass):
                     ladish_room = gDBus.bus.get_object("org.ladish", room_path)
                     room_name = ladish_room.GetName()
                     act_x_room = QAction(room_name, self.ui.menu_room_delete)
+                    act_x_room.setProperty("data", studio_name);
                     self.ui.menu_room_delete.addAction(act_x_room)
                     act_x_room.triggered.connect(self.slot_room_delete_m)
         else:
@@ -1994,6 +1997,7 @@ class ClaudiaMainW(AbstractCanvasJackClass):
 
                 act_x_text = "%s [%s]" % (proj_name, proj_path)
                 act_x_proj = QAction(act_x_text, self.ui.menu_project_load)
+                act_x_proj.setProperty("data", act_x_text);
                 self.ui.menu_project_load.addAction(act_x_proj)
                 act_x_proj.triggered.connect(self.slot_project_load_m)
 

--- a/src/claudia_launcher.py
+++ b/src/claudia_launcher.py
@@ -703,6 +703,11 @@ class ClaudiaLauncher(QWidget, ui_claudia_launcher.Ui_ClaudiaLauncherW):
                     if installed == "install":
                         pkglist.append(package.strip())
 
+            elif os.path.exists("/bin/rpm"):
+                pkg_out = getoutput("env LANG=C /bin/rpm -qa --qf \"%{NAME}\n\" 2>/dev/null").split("\n")
+                for package in pkg_out:
+                    pkglist.append(package)
+
             if not "bristol" in pkglist:
                 self.tabWidget.setTabEnabled(iTabBristol, False)
 

--- a/src/jacksettings.py
+++ b/src/jacksettings.py
@@ -706,10 +706,12 @@ class JackSettingsW(QDialog):
     # -----------------------------------------------------------------
     # Helper functions
 
-    def getAlsaDeviceList(self):
+    def getAlsaDeviceList(self, playback=True):
         alsaDeviceList = []
 
-        aplay_out = getoutput("env LANG=C LC_ALL=C aplay -l").split("\n")
+        executable = 'aplay' if playback else 'arecord'
+
+        aplay_out = getoutput("env LANG=C LC_ALL=C {} -l".format(executable)).split("\n")
         for line in aplay_out:
             line = line.strip()
             if line.startswith("card "):
@@ -792,10 +794,12 @@ class JackSettingsW(QDialog):
             self.ui.obj_driver_playback.addItem("none")
 
             if LINUX:
-                dev_list = self.getAlsaDeviceList()
-                for dev in dev_list:
-                    self.ui.obj_driver_capture.addItem(dev)
+                dev_list_playback = self.getAlsaDeviceList(playback=True)
+                dev_list_record = self.getAlsaDeviceList(playback=False)
+                for dev in dev_list_playback:
                     self.ui.obj_driver_playback.addItem(dev)
+                for dev in dev_list_record:
+                    self.ui.obj_driver_capture.addItem(dev)
             else:
                 dev_list = gJackctl.GetParameterConstraint(["driver", "device"])[3]
                 for i in range(len(dev_list)):

--- a/src/jacksettings.py
+++ b/src/jacksettings.py
@@ -404,28 +404,30 @@ class JackSettingsW(QDialog):
             elif attribute == "alias":
                 self.ui.obj_server_alias.setChecked(bool(value))
             elif attribute == "client-timeout":
-                self.setComboBoxValue(self.ui.obj_server_client_timeout, str(value))
+                self.setComboBoxValue(self.ui.obj_server_client_timeout, str(int(value)))
             elif attribute == "clock-source":
-                value = str(value)
-                if value == "c":
-                    self.ui.obj_server_clock_source_cycle.setChecked(True)
-                elif value == "h":
-                    self.ui.obj_server_clock_source_hpet.setChecked(True)
-                elif value == "s":
-                    self.ui.obj_server_clock_source_system.setChecked(True)
-                else:
-                    self.fBrokenServerClockSource = True
-                    if value == str(JACK_TIMER_SYSTEM_CLOCK):
-                        self.ui.obj_server_clock_source_system.setChecked(True)
-                    elif value == str(JACK_TIMER_CYCLE_COUNTER):
+                if len(str(value)) == 1 :
+                    value = str(value)
+                    if value == "c":
                         self.ui.obj_server_clock_source_cycle.setChecked(True)
-                    elif value == str(JACK_TIMER_HPET):
+                    elif value == "h":
+                        self.ui.obj_server_clock_source_hpet.setChecked(True)
+                    elif value == "s":
+                        self.ui.obj_server_clock_source_system.setChecked(True)
+                else:
+                    value = int(value)
+                    self.fBrokenServerClockSource = True
+                    if value == JACK_TIMER_SYSTEM_CLOCK:
+                        self.ui.obj_server_clock_source_system.setChecked(True)
+                    elif value == JACK_TIMER_CYCLE_COUNTER:
+                        self.ui.obj_server_clock_source_cycle.setChecked(True)
+                    elif value == JACK_TIMER_HPET:
                         self.ui.obj_server_clock_source_hpet.setChecked(True)
                     else:
                         self.ui.obj_server_clock_source.setEnabled(False)
                         print("JackSettingsW::saveServerSettings() - Invalid clock-source value '%s'" % value)
             elif attribute == "port-max":
-                self.setComboBoxValue(self.ui.obj_server_port_max, str(value))
+                self.setComboBoxValue(self.ui.obj_server_port_max, str(int(value)))
             elif attribute == "replace-registry":
                 self.ui.obj_server_replace_registry.setChecked(bool(value))
             elif attribute == "sync":
@@ -627,17 +629,21 @@ class JackSettingsW(QDialog):
             elif attribute == "capture":
                 if self.fDriverName == "firewire":
                     self.ui.obj_driver_capture.setCurrentIndex(1 if bool(value) else 0)
+                elif self.fDriverName == "dummy":
+                    self.setComboBoxValue(self.ui.obj_driver_capture, str(int(value)), True)
                 else:
                     self.setComboBoxValue(self.ui.obj_driver_capture, str(value), True)
             elif attribute == "playback":
                 if self.fDriverName == "firewire":
                     self.ui.obj_driver_playback.setCurrentIndex(1 if bool(value) else 0)
+                elif self.fDriverName == "dummy":
+                    self.setComboBoxValue(self.ui.obj_driver_playback, str(int(value)), True)
                 else:
                     self.setComboBoxValue(self.ui.obj_driver_playback, str(value), True)
             elif attribute == "rate":
-                self.setComboBoxValue(self.ui.obj_driver_rate, str(value))
+                self.setComboBoxValue(self.ui.obj_driver_rate, str(int(value)))
             elif attribute == "period":
-                self.setComboBoxValue(self.ui.obj_driver_period, str(value))
+                self.setComboBoxValue(self.ui.obj_driver_period, str(int(value)))
             elif attribute == "nperiods":
                 self.ui.obj_driver_nperiods.setValue(int(value))
             elif attribute == "hwmon":


### PR DESCRIPTION
So. I made something really better I think.
this way cadence-pulse2jack write a tmp .pa file before load it if pulseaudio is not started. ".pa" files are so not needed anymore (note: I didn't remove them).
I add options to script to set number of playback and capture channels.

example for stereo inputs/outputs
`cadence-pulse2jack -c 2 -p 2`
Note: cadence-pulse2jack -p makes exactly the same thing than before, so users using this script won't be disturbed.

When pulseaudio is already bridged, the script only reloads modules which need it. Also, you can add/remove capture without reload Playback and don't need to restart apps needing playback.

In Cadence, I removed the options button (unneeded anymore) and add a "Channels" button near start/stop. It opens a dialog where user can set number of capture/playback channels. If pulseaudio is yet bridged, these number of channels is directly modified.

I add a menu "Channels" to systray too.
