### PR TITLE
Corrected ALSA capture device list on Linux.

### DIFF
--- a/src/jacksettings.py
+++ b/src/jacksettings.py
@@ -700,10 +700,12 @@ class JackSettingsW(QDialog):
     # -----------------------------------------------------------------
     # Helper functions
 
-    def getAlsaDeviceList(self):
+    def getAlsaDeviceList(self, playback=True):
         alsaDeviceList = []
 
-        aplay_out = getoutput("env LANG=C LC_ALL=C aplay -l").split("\n")
+        executable = 'aplay' if playback else 'arecord'
+
+        aplay_out = getoutput("env LANG=C LC_ALL=C {} -l".format(executable)).split("\n")
         for line in aplay_out:
             line = line.strip()
             if line.startswith("card "):
@@ -786,10 +788,12 @@ class JackSettingsW(QDialog):
             self.ui.obj_driver_playback.addItem("none")
 
             if LINUX:
-                dev_list = self.getAlsaDeviceList()
-                for dev in dev_list:
-                    self.ui.obj_driver_capture.addItem(dev)
+                dev_list_playback = self.getAlsaDeviceList(playback=True)
+                dev_list_record = self.getAlsaDeviceList(playback=False)
+                for dev in dev_list_playback:
                     self.ui.obj_driver_playback.addItem(dev)
+                for dev in dev_list_record:
+                    self.ui.obj_driver_capture.addItem(dev)
             else:
                 dev_list = gJackctl.GetParameterConstraint(["driver", "device"])[3]
                 for i in range(len(dev_list)):


### PR DESCRIPTION
This modifies the ALSA input device list to use the output of `arecord -l` instead of `aplay -l`.
With this, audio devices that are input-only are correctly shown in the capture list, and non-input devices are also hidden.