### PR TITLE
Refine #256

### DIFF
--- a/resources/ui/cadence.ui
+++ b/resources/ui/cadence.ui
@@ -785,7 +785,7 @@
                    <item>
                     <widget class="QPushButton" name="b_a2j_export_hw">
                      <property name="text">
-                      <string>Export HW ports and (re)start</string>
+                      <string>Export HW ports</string>
                      </property>
                     </widget>
                    </item>


### PR DESCRIPTION
- ~~Disable 'Export HW port' when JACK is not running~~
- Fix 'Export HW port' tray option not working and incorrect state
- Disable 'Export HW port' when ports are already exported and notify it
with the button text
- Do not start A2JMIDI after exporting ports
- Stop A2JMIDI before stopping JACK


~~Reasoning:~~
- ~~It doesn't make sense to only export ports
while not starting A2J: Either you don't want to export the ports at all
if for example your soundcard crashes A2J when exporting its ports, or
you want your ports exported which means it starts A2J as well.~~
- ~~If you plug a new hw, just export hw ports again and it will stop/start
A2J if needed~~.