### PR TITLE
Ensure a2j is started before attempting to stop it

### DIFF
--- a/src/cadence.py
+++ b/src/cadence.py
@@ -1667,7 +1667,7 @@ class CadenceMainW(QMainWindow, ui_cadence.Ui_CadenceMainW):
 
     @pyqtSlot()
     def slot_JackServerStop(self):
-        if gDBus.a2j:
+        if gDBus.a2j and bool(gDBus.a2j.is_started()):
             gDBus.a2j.stop()
         try:
             gDBus.jack.StopServer()


### PR DESCRIPTION
When stopping jackd, ensure that a2j is actually started before
attempting to stop it. Otherwise we get an error and jackd is not
stopped.