### PR TITLE
catia/claudia: fix startup when a2j not present

### DIFF
--- a/src/catia.py
+++ b/src/catia.py
@@ -1009,7 +1009,7 @@ class CatiaMainW(AbstractCanvasJackClass):
         if gDBus.jack and not gDBus.jack.IsStarted():
             self.ui.act_tools_a2j_start.setEnabled(False)
             self.ui.act_tools_a2j_stop.setEnabled(False)
-            self.ui.act_tools_a2j_export_hw.setEnabled(gDBus.a2j and not gDBus.a2j.is_started())
+            self.ui.act_tools_a2j_export_hw.setEnabled(bool(gDBus.a2j) and not gDBus.a2j.is_started())
         else:
             self.ui.act_tools_a2j_start.setEnabled(not started)
             self.ui.act_tools_a2j_stop.setEnabled(started)

--- a/src/claudia.py
+++ b/src/claudia.py
@@ -1515,7 +1515,7 @@ class ClaudiaMainW(AbstractCanvasJackClass):
         if not gDBus.jack.IsStarted():
             self.ui.act_tools_a2j_start.setEnabled(False)
             self.ui.act_tools_a2j_stop.setEnabled(False)
-            self.ui.act_tools_a2j_export_hw.setEnabled(gDBus.a2j and not gDBus.a2j.is_started())
+            self.ui.act_tools_a2j_export_hw.setEnabled(bool(gDBus.a2j) and not gDBus.a2j.is_started())
         else:
             self.ui.act_tools_a2j_start.setEnabled(not started)
             self.ui.act_tools_a2j_stop.setEnabled(started)


### PR DESCRIPTION
Consider this code:
```
a = None
print(a and a.b)
```
This evaluates to None and not to False.

Closes: #274