### PR TITLE
Fix build with Qt 5.15+

### DIFF
--- a/c++/widgets/pixmapdial.cpp
+++ b/c++/widgets/pixmapdial.cpp
@@ -22,6 +22,7 @@
 #include <QtCore/QTimer>
 #include <QtGui/QPainter>
 #include <QtGui/QPaintEvent>
+#include <QtGui/QPainterPath>
 
 PixmapDial::PixmapDial(QWidget* parent)
     : QDial(parent),


### PR DESCRIPTION
Building with Qt 5.15 failed with the following error:
```
../widgets/pixmapdial.cpp:231:26: error: aggregate ‘QPainterPath ballPath’ has incomplete type and cannot be defined
  231 |             QPainterPath ballPath;
      |                          ^~~~~~~~
../widgets/pixmapdial.cpp:278:26: error: aggregate ‘QPainterPath ballPath’ has incomplete type and cannot be defined
  278 |             QPainterPath ballPath;
      |                          ^~~~~~~~
```