### PR TITLE
pulse2jack: Add the option to use a user-selected config file

### DIFF
--- a/data/cadence-pulse2jack
+++ b/data/cadence-pulse2jack
@@ -68,11 +68,23 @@ exit
 
     -p|--p|--play)
 PLAY_ONLY="yes"
-FILE=$INSTALL_PREFIX/share/cadence/pulse2jack/play.pa
+if test -n "${CADENCE_PULSE2JACK_PLAY}"; then
+	FILE="$CADENCE_PULSE2JACK_PLAY"
+elif test -f ~/.config/Cadence/pulse2jack/play.pa; then
+	FILE=~/.config/Cadence/pulse2jack/play.pa
+else
+	FILE=$INSTALL_PREFIX/share/cadence/pulse2jack/play.pa
+fi
     ;;
 
     *)
-FILE=$INSTALL_PREFIX/share/cadence/pulse2jack/play+rec.pa
+if test -n "${CADENCE_PULSE2JACK_PLAYREC}"; then
+	FILE="$CADENCE_PULSE2JACK_PLAYREC"
+elif test -f ~/.config/Cadence/pulse2jack/play+rec.pa; then
+	FILE=~/.config/Cadence/pulse2jack/play+rec.pa
+else
+	FILE=$INSTALL_PREFIX/share/cadence/pulse2jack/play+rec.pa
+fi
     ;;
 esac
 


### PR DESCRIPTION
The pulse configuration file is selected from, in order:
- An environment variable
  - CADENCE_PULSE2JACK_PLAY/CADENCE_PULSE2JACK_PLAYREC
- A file
  - ~/.config/Cadence/pulse2jack/play[+rec].pa
- The original default file
  - $INSTALL_PREFIX/share/cadence/pulse2jack/play[+rec].pa

I know there are a couple PRs for #234 that have stalled out and I thought this might be an easier most-of-the-way solution to get merged. I'm using it myself currently.

If anyone wants to test it out, you can put the cadence-pulse2jack file in e.g. ~/bin and prefix it to your $PATH in your bashrc, making sure to start cadence from the command line or somewhere else with the correct $PATH.