### PR TITLE
Fix for claudia not starting

### DIFF
--- a/src/canvaspreviewframe.py
+++ b/src/canvaspreviewframe.py
@@ -73,8 +73,8 @@ class CanvasPreviewFrame(QFrame):
         self.fFakeWidth  = float(realWidth) / 15
         self.fFakeHeight = float(realHeight) / 15
 
-        self.setMinimumSize(self.fFakeWidth+padding,   self.fFakeHeight+padding)
-        self.setMaximumSize(self.fFakeWidth*4+padding, self.fFakeHeight+padding)
+        self.setMinimumSize(int(self.fFakeWidth+padding),   int(self.fFakeHeight+padding))
+        self.setMaximumSize(int(self.fFakeWidth*4+padding), int(self.fFakeHeight+padding))
 
         self.fRenderTarget.setWidth(realWidth)
         self.fRenderTarget.setHeight(realHeight)
@@ -198,7 +198,7 @@ class CanvasPreviewFrame(QFrame):
 
         painter.setBrush(self.fViewBrush)
         painter.setPen(self.fViewPen)
-        painter.drawRect(self.fViewRect[iX], self.fViewRect[iY], maxWidth, maxHeight)
+        painter.drawRect(QRectF(self.fViewRect[iX], self.fViewRect[iY], maxWidth, maxHeight))
 
         if self.fUseCustomPaint:
             event.accept()

--- a/src/canvaspreviewframe.py
+++ b/src/canvaspreviewframe.py
@@ -56,8 +56,8 @@ class CanvasPreviewFrame(QFrame):
         self.fScale = 1.0
         self.fScene = None
         self.fRealParent = None
-        self.fFakeWidth  = 0.0
-        self.fFakeHeight = 0.0
+        self.fFakeWidth  = 0
+        self.fFakeHeight = 0
 
         self.fRenderSource = self.getRenderSource()
         self.fRenderTarget = QRectF(0, 0, 0, 0)
@@ -70,11 +70,11 @@ class CanvasPreviewFrame(QFrame):
         padding = 6
 
         self.fScene = scene
-        self.fFakeWidth  = float(realWidth) / 15
-        self.fFakeHeight = float(realHeight) / 15
+        self.fFakeWidth  = int(realWidth / 15)
+        self.fFakeHeight = int(realHeight / 15)
 
-        self.setMinimumSize(int(self.fFakeWidth+padding),   int(self.fFakeHeight+padding))
-        self.setMaximumSize(int(self.fFakeWidth*4+padding), int(self.fFakeHeight+padding))
+        self.setMinimumSize(self.fFakeWidth+padding,   self.fFakeHeight+padding)
+        self.setMaximumSize(self.fFakeWidth*4+padding, self.fFakeHeight+padding)
 
         self.fRenderTarget.setWidth(realWidth)
         self.fRenderTarget.setHeight(realHeight)


### PR DESCRIPTION
This change fixes an issue in which Claudia won't start from Cadence or the terminal.

- Python  - 3.10.4
- PyQt5   -  5.15.6
-  Linux  5.17.1 x86_64 

Traceback (most recent call last):
  File "/usr/share/cadence/src/claudia.py", line 2768, in <module>
    gui = ClaudiaMainW()
  File "/usr/share/cadence/src/claudia.py", line 786, in __init__
    self.ui.miniCanvasPreview.init(self.scene, DEFAULT_CANVAS_WIDTH, DEFAULT_CANVAS_HEIGHT)
  File "/usr/share/cadence/src/canvaspreviewframe.py", line 76, in init
    self.setMinimumSize(self.fFakeWidth+padding,   self.fFakeHeight+padding)
TypeError: arguments did not match any overloaded call:
  setMinimumSize(self, int, int): argument 1 has unexpected type 'float'
  setMinimumSize(self, QSize): argument 1 has unexpected type 'float'
